### PR TITLE
Dockerfile: Fix issue with path to gmes_linux_64*.tar.gz

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM taniguti/fungap-base:v1.1.1
 ENV FUNGAP_DIR=/workspace/FunGAP
 
 # Install GeneMark
-COPY gmes_linux_64.tar.gz /workspace/FunGAP/external/
+COPY gmes_linux_64_4.tar.gz /workspace/FunGAP/external/
 COPY gm_key_64.gz /workspace/FunGAP/external/
 
 


### PR DESCRIPTION
I ran into an issue where the Dockerfile copied in the `gmes_linux_64.tar.gz`, but later tried to untar `gmes_linux_64_4.tar.gz` (the one reported to be for kernel 3.10 - 5). 

This fix changes the `COPY` to copy in the one it tries to untar.